### PR TITLE
Add basic getting started info to index when there are no features

### DIFF
--- a/lib/flipper/ui/assets/javascripts/application.coffee
+++ b/lib/flipper/ui/assets/javascripts/application.coffee
@@ -99,7 +99,12 @@ class App.FeatureList extends Spine.Controller
 
   addAll: =>
     @html ''
-    @addOne feature for feature in Feature.all()
+    $('#no_features').hide()
+    all_features = Feature.all()
+    if all_features.length > 0
+      @addOne feature for feature in all_features
+    else
+      $('#no_features').show()
 
 class App.Feature extends Spine.Controller
   elements:

--- a/lib/flipper/ui/assets/stylesheets/application.scss
+++ b/lib/flipper/ui/assets/stylesheets/application.scss
@@ -63,6 +63,18 @@ body {
   padding: 29px 0 22px;
 }
 
+div#no_features {
+  display: none;
+  h1 {
+    font-size: 2em;
+    padding-bottom: 15px;
+  }
+  p {
+    font-size: 1.25em;
+    padding-bottom: 5px;
+  }
+}
+
 div.feature {
   float:left;
   width:723px;

--- a/lib/flipper/ui/public/css/application.css
+++ b/lib/flipper/ui/public/css/application.css
@@ -58,6 +58,15 @@ body {
 #header {
   padding: 29px 0 22px; }
 
+div#no_features {
+  display: none; }
+  div#no_features h1 {
+    font-size: 2em;
+    padding-bottom: 15px; }
+  div#no_features p {
+    font-size: 1.25em;
+    padding-bottom: 5px; }
+
 div.feature {
   float: left;
   width: 723px;

--- a/lib/flipper/ui/public/js/application.js
+++ b/lib/flipper/ui/public/js/application.js
@@ -131,9 +131,7 @@
 
     function FeatureList() {
       this.addAll = __bind(this.addAll, this);
-
       this.addOne = __bind(this.addOne, this);
-
       var _this = this;
       FeatureList.__super__.constructor.apply(this, arguments);
       this.feature_controllers = {};
@@ -177,15 +175,20 @@
     };
 
     FeatureList.prototype.addAll = function() {
-      var feature, _i, _len, _ref, _results;
+      var all_features, feature, _i, _len, _results;
       this.html('');
-      _ref = Feature.all();
-      _results = [];
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        feature = _ref[_i];
-        _results.push(this.addOne(feature));
+      $('#no_features').hide();
+      all_features = Feature.all();
+      if (all_features.length > 0) {
+        _results = [];
+        for (_i = 0, _len = all_features.length; _i < _len; _i++) {
+          feature = all_features[_i];
+          _results.push(this.addOne(feature));
+        }
+        return _results;
+      } else {
+        return $('#no_features').show();
       }
-      return _results;
     };
 
     return FeatureList;
@@ -209,7 +212,7 @@
 
     function Feature() {
       Feature.__super__.constructor.apply(this, arguments);
-      if (!(this.feature != null)) {
+      if (this.feature == null) {
         throw "@feature required";
       }
     }
@@ -337,7 +340,7 @@
     __extends(Set, _super);
 
     function Set() {
-      return Set.__super__.constructor.apply(this, arguments);
+      Set.__super__.constructor.apply(this, arguments);
     }
 
     Set.prototype.elements = {
@@ -405,7 +408,7 @@
     __extends(Percentage, _super);
 
     function Percentage() {
-      return Percentage.__super__.constructor.apply(this, arguments);
+      Percentage.__super__.constructor.apply(this, arguments);
     }
 
     Percentage.prototype.elements = {
@@ -457,7 +460,7 @@
     __extends(GateList, _super);
 
     function GateList() {
-      return GateList.__super__.constructor.apply(this, arguments);
+      GateList.__super__.constructor.apply(this, arguments);
     }
 
     GateList.prototype.controllers = {

--- a/lib/flipper/ui/public/js/spine/ajax.js
+++ b/lib/flipper/ui/public/js/spine/ajax.js
@@ -106,9 +106,7 @@
     function Collection(model) {
       this.model = model;
       this.failResponse = __bind(this.failResponse, this);
-
       this.recordsResponse = __bind(this.recordsResponse, this);
-
     }
 
     Collection.prototype.find = function(id, params) {
@@ -169,9 +167,7 @@
     function Singleton(record) {
       this.record = record;
       this.failResponse = __bind(this.failResponse, this);
-
       this.recordResponse = __bind(this.recordResponse, this);
-
       this.model = this.record.constructor;
     }
 

--- a/lib/flipper/ui/public/js/spine/list.js
+++ b/lib/flipper/ui/public/js/spine/list.js
@@ -19,8 +19,7 @@
     List.prototype.selectFirst = false;
 
     function List() {
-      this.change = __bind(this.change, this);
-      List.__super__.constructor.apply(this, arguments);
+      this.change = __bind(this.change, this);      List.__super__.constructor.apply(this, arguments);
       this.bind('change', this.change);
     }
 

--- a/lib/flipper/ui/public/js/spine/spine.js
+++ b/lib/flipper/ui/public/js/spine/spine.js
@@ -668,7 +668,6 @@
 
     function Controller(options) {
       this.release = __bind(this.release, this);
-
       var key, value, _ref;
       this.options = options;
       _ref = this.options;
@@ -885,7 +884,7 @@
       __extends(Result, _super);
 
       function Result() {
-        return Result.__super__.constructor.apply(this, arguments);
+        Result.__super__.constructor.apply(this, arguments);
       }
 
       return Result;
@@ -913,7 +912,7 @@
       __extends(Instance, _super);
 
       function Instance() {
-        return Instance.__super__.constructor.apply(this, arguments);
+        Instance.__super__.constructor.apply(this, arguments);
       }
 
       return Instance;

--- a/lib/flipper/ui/views/index.erb
+++ b/lib/flipper/ui/views/index.erb
@@ -1,3 +1,9 @@
 <div id="features">
   <p>loading indicator...</p>
 </div>
+
+<div id="no_features">
+  <h1>Ready to start flipping?</h1>
+  <p>You haven't created any features yet</p>
+  <p>Start by reading the <a href='https://github.com/jnunemaker/flipper#usage'>flipper readme</p>
+</div>


### PR DESCRIPTION
In response to #10

Simple hidden / shown div for now (can move to be handlebars template if needs to be dynamic / for consistency)

TODO:
- [ ] Add actual getting started info (not just link to flipper readme)
- [ ] Maybe refactor so no_features div isn't being shown by `addAll` function
